### PR TITLE
Update PHP and tools to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.1-apache
+FROM php:7.4.6-apache
 
 MAINTAINER Giulio Troccoli-Allard
 
@@ -16,8 +16,8 @@ RUN a2enmod rewrite
 # - pdo_mysql: required by PDO to connect to a MySQL database
 RUN docker-php-ext-install gd zip pdo_mysql calendar bcmath soap
 
-# Install NodeJS 8.x
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && apt-get install -y nodejs
+# Install NodeJS 14.x
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install -y nodejs
 
 # Install Composer
 RUN php -r "readfile('https://getcomposer.org/installer');" > composer-setup.php && \

--- a/config/composer.json
+++ b/config/composer.json
@@ -1,9 +1,9 @@
 {
   "require": {
-    "squizlabs/php_codesniffer": "^3.5.3",
-    "friendsofphp/php-cs-fixer": "^2.16.1",
-    "phpmd/phpmd": "^2.8.1",
-    "phpstan/phpstan": "^0.12.3",
+    "squizlabs/php_codesniffer": "^3.5.5",
+    "friendsofphp/php-cs-fixer": "^2.16.3",
+    "phpmd/phpmd": "^2.8.2",
+    "phpstan/phpstan": "^0.12.25",
     "jakub-onderka/php-parallel-lint": "^1.0.0",
     "sensiolabs/security-checker": "^6.0.3"
   }


### PR DESCRIPTION
PHP has been updated to 7.4.6.

The following tools and packages have also been updated:

nodejs -> 14
npm ->
PHP CodeSniffer -> 3.5.5
PHP CSFixer -> 2.16.3
phpmd -> 2.8.2
phpstan -> 0.12.25